### PR TITLE
Generators: allow decorators not to match controller names

### DIFF
--- a/lib/generators/controller_override.rb
+++ b/lib/generators/controller_override.rb
@@ -1,17 +1,24 @@
 require "rails/generators"
 require "rails/generators/rails/controller/controller_generator"
 require "rails/generators/rails/scaffold_controller/scaffold_controller_generator"
+require "rails/generators/model_helpers"
 
 module Rails
   module Generators
     class ControllerGenerator
+      include Rails::Generators::ModelHelpers
+
+      class_option :model_name, type: :string, desc: "ModelName to be used"
+
       hook_for :decorator, type: :boolean, default: true do |generator|
-        invoke generator, [name.singularize]
+        invoke generator, [options[:model_name] || name]
       end
     end
 
     class ScaffoldControllerGenerator
-      hook_for :decorator, type: :boolean, default: true
+      hook_for :decorator, type: :boolean, default: true do |generator|
+        invoke generator, [options[:model_name] || name]
+      end
     end
   end
 end

--- a/spec/generators/controller/controller_generator_spec.rb
+++ b/spec/generators/controller/controller_generator_spec.rb
@@ -5,19 +5,65 @@ require 'generators/controller_override'
 require 'generators/rails/decorator_generator'
 SimpleCov.command_name 'test:generator'
 
-describe Rails::Generators::ControllerGenerator do
-  destination File.expand_path("../tmp", __FILE__)
+describe Rails::Generators do
+  destination Rails.root / 'tmp/generated'
+
+  subject { file path }
+
+  let(:controller_name) { 'YourModels' }
+  let(:model_name)      { controller_name.singularize }
+  let(:decorator_name)  { "#{model_name}Decorator" }
+  let(:options)         { {} }
+  let(:args)            { options.map { |k, v| "--#{k.to_s.dasherize}=#{v}" } }
 
   before { prepare_destination }
-  after(:all) { FileUtils.rm_rf destination_root }
+  before { run_generator [controller_name, *args] }
 
-  describe "the generated decorator" do
-    subject { file("app/decorators/your_model_decorator.rb") }
+  shared_context :namespaceable do
+    let(:controller_name) { 'Namespace::YourModels' }
+    let(:model_name)      { options[:model_name] or super() }
 
-    describe "naming" do
-      before { run_generator %w(YourModels) }
+    include_examples :naming
 
-      it { is_expected.to contain "class YourModelDecorator" }
+    context "with the same namespace" do
+      let(:options) { super().merge model_name: 'Namespace::OtherModel' }
+
+      include_examples :naming
+    end
+
+    context "with another namespace" do
+      let(:options) { super().merge model_name: 'OtherNamespace::YourModel' }
+
+      include_examples :naming
+    end
+
+    context "without namespace" do
+      let(:options) { super().merge model_name: 'YourModel' }
+
+      include_examples :naming
+    end
+  end
+
+  describe "decorator class" do
+    let(:path) { "app/decorators/#{decorator_name.underscore}.rb" }
+
+    shared_examples :naming do
+      it 'is properly named' do
+        is_expected.to exist
+        is_expected.to contain "class #{decorator_name}"
+      end
+    end
+
+    describe Rails::Generators::ControllerGenerator do
+      include_examples :naming
+      it_behaves_like :namespaceable
+    end
+
+    describe Rails::Generators::ScaffoldControllerGenerator do
+      let(:options) { { skip_routes: true } }
+
+      include_examples :naming
+      it_behaves_like :namespaceable
     end
   end
 end


### PR DESCRIPTION
## Description

Decorator will respect `--model-name` passed to `scaffold_controller` or `controller` generator.

That could be of a particular use to solve namespace issues (e.g. when controllers are namespaced and models are not).

The specs have been refactored to reduce and DRY the code.

## Testing

1. Use `controller` or `scaffold_controller` generator with `--model-name` option.
2. Check if the generated decorator matches the model name.

## To-Dos

- [x] tests

## References

* #919
